### PR TITLE
Adds ability to pass cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ viewport.deviceScaleFactor | number | `1` | Device scale factor (could be though
 viewport.isMobile | boolean | `false` | Whether the meta viewport tag is taken into account.
 viewport.hasTouch | boolean | `false` | Specifies if viewport supports touch events.
 viewport.isLandscape | boolean | `false` | Specifies if viewport is in landscape mode.
+cookies[].name | string | - | Cookie name (required)
+cookies[].value | string | - | Cookie value (required)
+cookies[].url | string | - | Cookie url
+cookies[].domain | string | - | Cookie domain
+cookies[].path | string | - | Cookie path
+cookies[].expires | number | - | Cookie expiry in unix time
+cookies[].httpOnly | boolean | - | Cookie httpOnly
+cookies[].secure | boolean | - | Cookie secure
+cookies[].sameSite | string | - | `Strict` or `Lax`
 goto.timeout | number | `30000` |  Maximum navigation time in milliseconds, defaults to 30 seconds, pass 0 to disable timeout.
 goto.waitUntil | string | `networkidle` | When to consider navigation succeeded. Options: `load`, `networkidle`. `load` = consider navigation to be finished when the load event is fired. `networkidle` = consider navigation to be finished when the network activity stays "idle" for at least `goto.networkIdleTimeout` ms.
 goto.networkIdleInflight | number | `2` | Maximum amount of inflight requests which are considered "idle". Takes effect only with `goto.waitUntil`: 'networkidle' parameter.
@@ -175,6 +184,9 @@ The only required parameter is `url`.
 
   // Passed to Puppeteer page.waitFor()
   waitFor: null,
+
+  // Passsed to Puppeteer page.setCookies()
+  cookies: [{ ... }]
 
   // Passed to Puppeteer page.setViewport()
   viewport: { ... },

--- a/README.md
+++ b/README.md
@@ -125,15 +125,15 @@ viewport.deviceScaleFactor | number | `1` | Device scale factor (could be though
 viewport.isMobile | boolean | `false` | Whether the meta viewport tag is taken into account.
 viewport.hasTouch | boolean | `false` | Specifies if viewport supports touch events.
 viewport.isLandscape | boolean | `false` | Specifies if viewport is in landscape mode.
-cookies[].name | string | - | Cookie name (required)
-cookies[].value | string | - | Cookie value (required)
-cookies[].url | string | - | Cookie url
-cookies[].domain | string | - | Cookie domain
-cookies[].path | string | - | Cookie path
-cookies[].expires | number | - | Cookie expiry in unix time
-cookies[].httpOnly | boolean | - | Cookie httpOnly
-cookies[].secure | boolean | - | Cookie secure
-cookies[].sameSite | string | - | `Strict` or `Lax`
+cookies[0][name] | string | - | Cookie name (required)
+cookies[0][value] | string | - | Cookie value (required)
+cookies[0][url] | string | - | Cookie url
+cookies[0][domain] | string | - | Cookie domain
+cookies[0][path] | string | - | Cookie path
+cookies[0][expires] | number | - | Cookie expiry in unix time
+cookies[0][httpOnly] | boolean | - | Cookie httpOnly
+cookies[0][secure] | boolean | - | Cookie secure
+cookies[0][sameSite] | string | - | `Strict` or `Lax`
 goto.timeout | number | `30000` |  Maximum navigation time in milliseconds, defaults to 30 seconds, pass 0 to disable timeout.
 goto.waitUntil | string | `networkidle` | When to consider navigation succeeded. Options: `load`, `networkidle`. `load` = consider navigation to be finished when the load event is fired. `networkidle` = consider navigation to be finished when the network activity stays "idle" for at least `goto.networkIdleTimeout` ms.
 goto.networkIdleInflight | number | `2` | Maximum amount of inflight requests which are considered "idle". Takes effect only with `goto.waitUntil`: 'networkidle' parameter.

--- a/src/core/pdf-core.js
+++ b/src/core/pdf-core.js
@@ -5,6 +5,7 @@ const logger = require('../util/logger')(__filename);
 
 async function render(_opts = {}) {
   const opts = _.merge({
+    cookies: [],
     scrollPage: false,
     emulateScreenMedia: true,
     viewport: {
@@ -52,8 +53,14 @@ async function render(_opts = {}) {
       await page.emulateMedia('screen');
     }
 
+    logger.info('Setting cookies..');
+    opts.cookies.map(async (cookie) => {
+      await page.setCookie(cookie)
+    });
+
     logger.info(`Goto url ${opts.url} ..`);
     await page.goto(opts.url, opts.goto);
+
 
     if (_.isNumber(opts.waitFor) || _.isString(opts.waitFor)) {
       logger.info(`Wait for ${opts.waitFor} ..`);

--- a/src/http/pdf-http.js
+++ b/src/http/pdf-http.js
@@ -7,6 +7,7 @@ const getRender = ex.createRoute((req, res) => {
     scrollPage: req.query.scrollPage,
     emulateScreenMedia: req.query.emulateScreenMedia,
     waitFor: req.query.waitFor,
+    cookies: req.query.cookies,
     viewport: {
       width: req.query['viewport.width'],
       height: req.query['viewport.height'],

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -7,6 +7,18 @@ const urlSchema = Joi.string().uri({
   ],
 });
 
+const cookieSchema = Joi.object({
+  name: Joi.string().required(),
+  value: Joi.string().required(),
+  url: Joi.string(),
+  domain: Joi.string(),
+  path: Joi.string(),
+  expires: Joi.number().min(1),
+  httpOnly: Joi.boolean(),
+  secure: Joi.boolean(),
+  sameSite: Joi.string().regex(/^(Strict|Lax)$/),
+})
+
 const renderQueryParams = Joi.object({
   url: urlSchema,
   scrollPage: Joi.boolean(),
@@ -15,6 +27,7 @@ const renderQueryParams = Joi.object({
     Joi.number().min(1).max(60000),
     Joi.string().min(1).max(2000),
   ]),
+  cookies: Joi.array().items(cookieSchema),
   'viewport.width': Joi.number().min(1).max(30000),
   'viewport.height': Joi.number().min(1).max(30000),
   'viewport.deviceScaleFactor': Joi.number().min(0).max(100),
@@ -43,6 +56,7 @@ const renderBodyParams = Joi.object({
   url: urlSchema,
   scrollPage: Joi.boolean(),
   emulateScreenMedia: Joi.boolean(),
+  cookies: Joi.array().items(cookieSchema),
   viewport: Joi.object({
     width: Joi.number().min(1).max(30000),
     height: Joi.number().min(1).max(30000),


### PR DESCRIPTION
This implements #9. 

- [x] Added Joi validations
- [x] Pass cookie to chome
- [x] testing using POST
- [x] tested using GET


Tested using [ARC](https://chrome.google.com/webstore/detail/advanced-rest-client/hgmloofddffdnphfgcellkdfbfbjeloo)

Link to [puppeteer setCookie docs](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetcookiecookies)