### PR TITLE
Implement support for render HTML input

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ https://url-to-pdf-api.herokuapp.com/api/render?url=http://google.com&waitFor=10
 
 https://url-to-pdf-api.herokuapp.com/api/render?url=http://google.com&waitFor=input
 
+**Render HTML from input**
+
+```bash
+curl -o html.pdf -XPOST -d'{"html": "<body>test</body>"}' -H"content-type: application/json" https://url-to-pdf-api.herokuapp.com/api/render
+```
 
 ## API
 
@@ -94,7 +99,11 @@ is really simple, check it out. Render flow:
 
 1. **`page.setViewport(options)`** where options matches `viewport.*`.
 2. *Possibly* **`page.emulateMedia('screen')`** if `emulateScreenMedia=true` is set.
-3. **`page.goto(url, options)`** where options matches `goto.*`.
+3. Render url **or** html.
+
+    If `url` is defined, **`page.goto(url, options)`** is called and options match `goto.*`.
+    Otherwise **`page.setContent(html)`** is called where html is taken from request body.
+
 4. *Possibly* **`page.waitFor(numOrStr)`** if e.g. `waitFor=1000` is set.
 5. *Possibly* **Scroll the whole page** to the end before rendering if e.g. `scrollPage=true` is set.
 
@@ -163,8 +172,11 @@ The only required parameter is `url`.
 
 ```js
 {
-  // Url to render
+  // Url to render. Either url or html is required
   url: "https://google.com",
+
+  // HTML content to render. Either url or html is required
+  html: "<html><head></head><body>Your content</body></html>",
 
   // If we should emulate @media screen instead of print
   emulateScreenMedia: true,
@@ -191,6 +203,10 @@ The only required parameter is `url`.
 
 ```bash
 curl -o google.pdf -XPOST -d'{"url": "http://google.com"}' -H"content-type: application/json" https://url-to-pdf-api.herokuapp.com/api/render
+```
+
+```bash
+curl -o html.pdf -XPOST -d'{"html": "<body>test</body>"}' -H"content-type: application/json" https://url-to-pdf-api.herokuapp.com/api/render
 ```
 
 ## Development

--- a/src/core/pdf-core.js
+++ b/src/core/pdf-core.js
@@ -7,6 +7,7 @@ async function render(_opts = {}) {
   const opts = _.merge({
     scrollPage: false,
     emulateScreenMedia: true,
+    html: null,
     viewport: {
       width: 1600,
       height: 1200,
@@ -18,7 +19,7 @@ async function render(_opts = {}) {
     pdf: {
       format: 'A4',
       printBackground: true,
-    }
+    },
   }, _opts);
 
   if (_.get(_opts, 'pdf.width') && _.get(_opts, 'pdf.height')) {
@@ -52,8 +53,13 @@ async function render(_opts = {}) {
       await page.emulateMedia('screen');
     }
 
-    logger.info(`Goto url ${opts.url} ..`);
-    await page.goto(opts.url, opts.goto);
+    if (opts.html) {
+      logger.info(`Set HTML ..`);
+      await page.setContent(opts.html);
+    } else {
+      logger.info(`Goto url ${opts.url} ..`);
+      await page.goto(opts.url, opts.goto);
+    }
 
     if (_.isNumber(opts.waitFor) || _.isString(opts.waitFor)) {
       logger.info(`Wait for ${opts.waitFor} ..`);

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -40,7 +40,8 @@ const renderQueryParams = Joi.object({
 });
 
 const renderBodyParams = Joi.object({
-  url: urlSchema.required(),
+  url: urlSchema,
+  html: Joi.string(),
   scrollPage: Joi.boolean(),
   emulateScreenMedia: Joi.boolean(),
   viewport: Joi.object({
@@ -77,7 +78,7 @@ const renderBodyParams = Joi.object({
     }),
     printBackground: Joi.boolean(),
   }),
-});
+}).xor('url', 'html');
 
 module.exports = {
   renderQueryParams,


### PR DESCRIPTION
Render any HTML input:


```bash
curl -o html.pdf -XPOST -d'{"html": "<body>test</body>"}' -H"content-type: application/json" http://localhost:9000/api/render
```
