### PR TITLE
Direct user to example+docs after Heroku deploy

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,7 +20,7 @@
       "required": false
     }
   },
-  "success_url": "/api/render?url=https://github.com/alvarcarto/url-to-pdf-api/blob/master/README.md"
+  "success_url": "/api/render?url=https://github.com/alvarcarto/url-to-pdf-api/blob/master/README.md",
   "buildpacks": [
     {
       "url": "https://github.com/jontewks/puppeteer-heroku-buildpack"

--- a/app.json
+++ b/app.json
@@ -20,6 +20,7 @@
       "required": false
     }
   },
+  "success_url": "/api/render?url=https://github.com/alvarcarto/url-to-pdf-api/blob/master/README.md"
   "buildpacks": [
     {
       "url": "https://github.com/jontewks/puppeteer-heroku-buildpack"


### PR DESCRIPTION
It would be great to show users how the API works upon successful deploy to Heroku.  Setting the `success_url` parameter in `app.json` will open up the specified URL on successful deploy.  To make it even more useful, I set it to the README for this project so the user can continue understanding how the API works.

EDIT: Also I'm considering highlighting this Heroku Button in Heroku's monthly newsletter.  Just FYI 😃 