### PR TITLE
Adding Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:8.6.0
+
+RUN mkdir -p /app
+COPY ./app.json /app/
+COPY ./package.json /app/
+WORKDIR /app
+RUN yarn
+RUN npm install
+
+ENV PORT 3035
+ENV NODE_ENV development
+
+EXPOSE 3035
+
+# docker build -t url-to-pdf-api .
+# docker run -it -v ${PWD}/src:/app/src url-to-pdf-api
+CMD ["node", "src", "server.js"]


### PR DESCRIPTION
This adds docker support to this app. It uses a modern Node image and only copies into the container the files necessary for building the project. It then mounts the source files at run time. This allows images to be reused between most commits without having to rebuild the whole Docker image.