### PR TITLE
Remove '--no-sandbox --disable-setuid-sandbox' flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ and requests are direct connections to it.
 
 * **By default, page's `@media print` CSS rules are ignored**. We set Chrome to emulate `@media screen` to make the default PDFs look more like actual sites. To get results closer to desktop Chrome, add `&emulateScreenMedia=false` query parameter. See more at [Puppeteer API docs](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions).
 
-* Chrome is launched with `--no-sandbox --disable-setuid-sandbox` flags to fix usage in Heroku. See [this issue](https://github.com/GoogleChrome/puppeteer/issues/290).
-
 * Heavy pages may cause Chrome to crash if the server doesn't have enough RAM.
 
 

--- a/src/core/pdf-core.js
+++ b/src/core/pdf-core.js
@@ -35,7 +35,7 @@ async function render(_opts = {}) {
   const browser = await puppeteer.launch({
     headless: !config.DEBUG_MODE,
     ignoreHTTPSErrors: opts.ignoreHttpsErrors,
-    args: ['--disable-gpu', '--no-sandbox', '--disable-setuid-sandbox'],
+    args: ['--disable-gpu'],
     sloMo: config.DEBUG_MODE ? 250 : undefined,
   });
   const page = await browser.newPage();


### PR DESCRIPTION
Removing these options due to Chrome vulnerability. See GoogleChrome/puppeteer#290.

This PR is probably not mergeable immediately, as there need to be some changes to our Heroku box. Could someone with access take a look at it?