### PR TITLE
Option to receive rendering as an attachment download

### DIFF
--- a/src/http/pdf-http.js
+++ b/src/http/pdf-http.js
@@ -6,6 +6,7 @@ const getRender = ex.createRoute((req, res) => {
   const opts = getOptsFromQuery(req.query);
   return pdfCore.render(opts)
     .then((data) => {
+      opts.attachmentName && res.attachment(opts.attachmentName);
       res.set('content-type', 'application/pdf');
       res.send(data);
     });
@@ -32,6 +33,7 @@ const postRender = ex.createRoute((req, res) => {
 
   return pdfCore.render(opts)
     .then((data) => {
+      opts.attachmentName && res.attachment(opts.attachmentName);
       res.set('content-type', 'application/pdf');
       res.send(data);
     });
@@ -40,6 +42,7 @@ const postRender = ex.createRoute((req, res) => {
 function getOptsFromQuery(query) {
   const opts = {
     url: query.url,
+    attachmentName: query.attachmentName,
     scrollPage: query.scrollPage,
     emulateScreenMedia: query.emulateScreenMedia,
     ignoreHttpsErrors: query.ignoreHttpsErrors,

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -20,6 +20,7 @@ const cookieSchema = Joi.object({
 });
 
 const sharedQuerySchema = Joi.object({
+  attachmentName: Joi.string(),
   scrollPage: Joi.boolean(),
   emulateScreenMedia: Joi.boolean(),
   ignoreHttpsErrors: Joi.boolean(),
@@ -59,6 +60,7 @@ const renderQuerySchema = Joi.object({
 const renderBodyObject = Joi.object({
   url: urlSchema,
   html: Joi.string(),
+  attachmentName: Joi.string(),
   scrollPage: Joi.boolean(),
   ignoreHttpsErrors: Joi.boolean(),
   emulateScreenMedia: Joi.boolean(),


### PR DESCRIPTION
By providing the query parameter `attachmentName` the response will have an attachment Content-Disposition header with the filename set to the value specified.  This can be used to receive the rendering as a file download