### PR TITLE
Upgrade Puppeteer to v1.0.0 (breaking change!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,12 +154,12 @@ cookies[0][httpOnly] | boolean | - | Cookie httpOnly
 cookies[0][secure] | boolean | - | Cookie secure
 cookies[0][sameSite] | string | - | `Strict` or `Lax`
 goto.timeout | number | `30000` |  Maximum navigation time in milliseconds, defaults to 30 seconds, pass 0 to disable timeout.
-goto.waitUntil | string | `networkidle` | When to consider navigation succeeded. Options: `load`, `networkidle`. `load` = consider navigation to be finished when the load event is fired. `networkidle` = consider navigation to be finished when the network activity stays "idle" for at least `goto.networkIdleTimeout` ms.
-goto.networkIdleInflight | number | `2` | Maximum amount of inflight requests which are considered "idle". Takes effect only with `goto.waitUntil`: 'networkidle' parameter.
-goto.networkIdleTimeout | number | `2000` | A timeout to wait before completing navigation. Takes effect only with waitUntil: 'networkidle' parameter.
+goto.waitUntil | array or string | `networkidle0` | When to consider navigation succeeded. Options: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`. `load` = consider navigation to be finished when the load event is fired. `domcontentloaded` = consider navigation to be finished when the DOMContentLoaded event is fired. `networkidle0` = consider navigation to be finished when there are no more than 0 network connections for at least 500 ms. `networkidle2` = consider navigation to be finished when there are no more than 2 network connections for at least 500 ms.
 pdf.scale | number | `1` | Scale of the webpage rendering.
 pdf.printBackground | boolean | `false`| Print background graphics.
 pdf.displayHeaderFooter | boolean | `false` | Display header and footer.
+pdf.headerTemplate | string | HTML template for the print header. Should be valid HTML markup following classes used to inject printing values into them. [List of classes](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions).
+pdf.footerTemplate | string | HTML template for the print footer. Should be valid HTML markup following classes used to inject printing values into them. [List of classes](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions).
 pdf.landscape | boolean | `false` | Paper orientation.
 pdf.pageRanges | string | - | Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means print all pages.
 pdf.format | string | `A4` | Paper format. If set, takes priority over width or height options.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "joi": "^11.1.1",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "puppeteer": "^0.11.0",
+    "puppeteer": "^1.0.0",
     "server-destroy": "^1.0.1",
     "winston": "^2.3.1"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -36,8 +36,8 @@ function createApp() {
   app.use(cors(corsOpts));
 
   // Limit to 10mb if HTML has e.g. inline images
-  app.use(bodyParser.text({ limit: '4mb', type: 'text/html' }));
-  app.use(bodyParser.json({ limit: '4mb' }));
+  app.use(bodyParser.text({ limit: '10mb', type: 'text/html' }));
+  app.use(bodyParser.json({ limit: '10mb' }));
 
   app.use(compression({
     // Compress everything over 10 bytes

--- a/src/core/pdf-core.js
+++ b/src/core/pdf-core.js
@@ -65,7 +65,7 @@ async function render(_opts = {}) {
     if (opts.html) {
       logger.info('Set HTML ..');
       // https://github.com/GoogleChrome/puppeteer/issues/728
-      await page.setContent(opts.html, opts.goto);
+      await page.goto(`data:text/html,${opts.html}`, opts.goto);
     } else {
       logger.info(`Goto url ${opts.url} ..`);
       await page.goto(opts.url, opts.goto);

--- a/src/core/pdf-core.js
+++ b/src/core/pdf-core.js
@@ -15,8 +15,8 @@ async function render(_opts = {}) {
       height: 1200,
     },
     goto: {
-      waitUntil: 'networkidle',
-      networkIdleTimeout: 2000,
+      waitUntil: 'networkidle0',
+      timeout: 2000,
     },
     pdf: {
       format: 'A4',
@@ -65,7 +65,7 @@ async function render(_opts = {}) {
     if (opts.html) {
       logger.info('Set HTML ..');
       // https://github.com/GoogleChrome/puppeteer/issues/728
-      await page.goto(`data:text/html,${opts.html}`, opts.goto);
+      await page.setContent(opts.html, opts.goto);
     } else {
       logger.info(`Goto url ${opts.url} ..`);
       await page.goto(opts.url, opts.goto);

--- a/src/http/pdf-http.js
+++ b/src/http/pdf-http.js
@@ -62,12 +62,12 @@ function getOptsFromQuery(query) {
     goto: {
       timeout: query['goto.timeout'],
       waitUntil: query['goto.waitUntil'],
-      networkIdleInflight: query['goto.networkIdleInflight'],
-      networkIdleTimeout: query['goto.networkIdleTimeout'],
     },
     pdf: {
       scale: query['pdf.scale'],
       displayHeaderFooter: query['pdf.displayHeaderFooter'],
+      headerTemplate: query['pdf.headerTemplate'],
+      footerTemplate: query['pdf.footerTemplate'],
       landscape: query['pdf.landscape'],
       pageRanges: query['pdf.pageRanges'],
       format: query['pdf.format'],

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -7,6 +7,11 @@ const urlSchema = Joi.string().uri({
   ],
 });
 
+const waitUntilSchema = Joi.alternatives([
+  Joi.string().min(1).max(2000),
+  Joi.array().items(Joi.string().min(1).max(2000)),
+]);
+
 const cookieSchema = Joi.object({
   name: Joi.string().required(),
   value: Joi.string().required(),
@@ -36,11 +41,11 @@ const sharedQuerySchema = Joi.object({
   'viewport.hasTouch': Joi.boolean(),
   'viewport.isLandscape': Joi.boolean(),
   'goto.timeout': Joi.number().min(0).max(60000),
-  'goto.waitUntil': Joi.string().min(1).max(2000),
-  'goto.networkIdleInflight': Joi.number().min(0).max(1000),
-  'goto.networkIdleTimeout': Joi.number().min(0).max(1000),
+  'goto.waitUntil': waitUntilSchema,
   'pdf.scale': Joi.number().min(0).max(1000),
   'pdf.displayHeaderFooter': Joi.boolean(),
+  'pdf.headerTemplate': Joi.string(),
+  'pdf.footerTemplate': Joi.string(),
   'pdf.landscape': Joi.boolean(),
   'pdf.pageRanges': Joi.string().min(1).max(2000),
   'pdf.format': Joi.string().min(1).max(2000),
@@ -79,13 +84,13 @@ const renderBodyObject = Joi.object({
   ]),
   goto: Joi.object({
     timeout: Joi.number().min(0).max(60000),
-    waitUntil: Joi.string().min(1).max(2000),
-    networkIdleInflight: Joi.number().min(0).max(1000),
-    networkIdleTimeout: Joi.number().min(0).max(1000),
+    waitUntil: waitUntilSchema,
   }),
   pdf: Joi.object({
     scale: Joi.number().min(0).max(1000),
     displayHeaderFooter: Joi.boolean(),
+    headerTemplate: Joi.string(),
+    footerTemplate: Joi.string(),
     landscape: Joi.boolean(),
     pageRanges: Joi.string().min(1).max(2000),
     format: Joi.string().min(1).max(2000),

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -69,6 +69,19 @@ describe('POST /api/render', () => {
       })
   );
 
+  it('rendering large html should succeed', () =>
+    request(app)
+      .post('/api/render')
+      .send(getResource('large.html'))
+      .set('content-type', 'text/html')
+      .expect(200)
+      .expect('content-type', 'application/pdf')
+      .then((response) => {
+        const length = Number(response.headers['content-length']);
+        chai.expect(length).to.be.above(1024 * 1024 * 1);
+      })
+  );
+
   it('html as text body should succeed', () =>
     request(app)
       .post('/api/render')


### PR DESCRIPTION
Puppeteer v1.0.0 introduced some breaking changes (weirdly enough these are not documented in the release notes)

- `goto.networkIdleInflight` and `goto.networkIdleTimeout` options are removed.
- `goto.waitUntil` has been changed; two new values have been added and `networkidle` is renamed to`networkidle0`.

[Puppeteer v1.0.0 release notes](https://github.com/GoogleChrome/puppeteer/releases/tag/v1.0.0).

It does bring two very nice new options: `pdf.headerTemplate` and `pdf.footerTemplate`. This also fixes #22.

I updated the new and changed options in the code and also updated the documentation.