### PR TITLE
Support for docker alpine image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:9-alpine
+
+RUN apk update && apk upgrade && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
+    apk add --no-cache \
+      chromium@edge \
+      nss@edge
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV HOST 0.0.0.0
+WORKDIR /usr/src/app
+COPY package.json .
+RUN npm install
+EXPOSE 9000
+CMD [ "node", "src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk update && apk upgrade && \
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV CHROME_PATH /usr/bin/chromium-browser
 ENV HOST 0.0.0.0
 WORKDIR /usr/src/app
 COPY package.json .

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -13,6 +13,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 WORKDIR /usr/src/app
 COPY package.json .
 ENV NODE_ENV production
+ENV CHROME_PATH /usr/bin/chromium-browser
 ENV ALLOW_HTTP true
 ENV HOST 0.0.0.0
 RUN npm install

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,21 @@
+FROM node:9-alpine
+
+RUN apk update && apk upgrade && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
+    apk add --no-cache \
+      chromium@edge \
+      nss@edge
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
+WORKDIR /usr/src/app
+COPY package.json .
+ENV NODE_ENV production
+ENV ALLOW_HTTP true
+ENV HOST 0.0.0.0
+RUN npm install
+COPY . .
+EXPOSE 9000
+CMD [ "node", "src/index.js"]

--- a/README.md
+++ b/README.md
@@ -280,6 +280,17 @@ First, clone the repository and cd into it.
 * `npm start` Start express server locally
 * Server runs at http://localhost:9000 or what `$PORT` env defines
 
+#### 3. Local development with docker
+
+* `docker-compose up`
+
+Server runs at http://localhost:9000 
+
+#### 4. Docker deployment (production)
+
+* `docker build -f Dockerfile.production .`
+
+NOTE: By default it will listen to all interfaces without authentification
 
 ### Techstack
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  app:
+    build: .
+    environment:
+      - NODE_ENV=development
+      - ALLOW_HTTP=true
+    ports:
+      - '9000:9000'
+    volumes:
+    - .:/usr/src/app
+    - node_modules:/usr/src/app/node_modules
+volumes:
+  app:
+  node_modules:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "joi": "^11.1.1",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "puppeteer": "^0.11.0",
+    "puppeteer": "^1.2.0",
     "server-destroy": "^1.0.1",
     "winston": "^2.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "joi": "^11.1.1",
     "lodash": "^4.17.4",
     "morgan": "^1.9.0",
-    "puppeteer": "^1.2.0",
+    "puppeteer": "^1.5.0",
     "server-destroy": "^1.0.1",
+    "uuid": "^3.2.1",
     "winston": "^2.3.1"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -35,13 +35,13 @@ function createApp() {
   logger.info('Using CORS options:', corsOpts);
   app.use(cors(corsOpts));
 
-  // Limit to 10mb if HTML has e.g. inline images
-  app.use(bodyParser.text({ limit: '4mb', type: 'text/html' }));
-  app.use(bodyParser.json({ limit: '4mb' }));
+  // Limit to 20mb if HTML has e.g. inline images
+  app.use(bodyParser.text({ limit: '20mb', type: 'text/html' }));
+  app.use(bodyParser.json({ limit: '20mb' }));
 
   app.use(compression({
     // Compress everything over 10 bytes
-    threshold: 10,
+    threshold: 1024,
   }));
 
   // Initialize routes

--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,7 @@ const config = {
   LOG_LEVEL: process.env.LOG_LEVEL,
   ALLOW_HTTP: process.env.ALLOW_HTTP === 'true',
   DEBUG_MODE: process.env.DEBUG_MODE === 'true',
-  TMP_PATH: process.env.TMP_PATH || (process.env.PWD + '/tmp'),
+  TMP_PATH: process.env.TMP_PATH || '/tmp',
   API_TOKENS: [],
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@
 // Env vars should be casted to correct types
 const config = {
   PORT: Number(process.env.PORT) || 9000,
+  HOST: process.env.HOST || 'localhost',
   NODE_ENV: process.env.NODE_ENV,
   LOG_LEVEL: process.env.LOG_LEVEL,
   ALLOW_HTTP: process.env.ALLOW_HTTP === 'true',

--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,7 @@ const config = {
   LOG_LEVEL: process.env.LOG_LEVEL,
   ALLOW_HTTP: process.env.ALLOW_HTTP === 'true',
   DEBUG_MODE: process.env.DEBUG_MODE === 'true',
+  TMP_PATH: process.env.TMP_PATH || (process.env.PWD + '/tmp'),
   API_TOKENS: [],
 };
 

--- a/src/core/pdf-core.js
+++ b/src/core/pdf-core.js
@@ -15,8 +15,8 @@ async function render(_opts = {}) {
       height: 1200,
     },
     goto: {
-      waitUntil: 'networkidle',
-      networkIdleTimeout: 2000,
+      waitUntil: 'networkidle0',
+      timeout: 5000,
     },
     pdf: {
       format: 'A4',

--- a/src/core/pdf-core.js
+++ b/src/core/pdf-core.js
@@ -32,13 +32,19 @@ async function render(_opts = {}) {
 
   logOpts(opts);
 
-  const browser = await puppeteer.launch({
+  const puppeterOptions = {
     headless: !config.DEBUG_MODE,
     ignoreHTTPSErrors: opts.ignoreHttpsErrors,
-    executablePath: '/usr/bin/chromium-browser',
     args: ['--disable-gpu', '--no-sandbox', '--disable-setuid-sandbox'],
     sloMo: config.DEBUG_MODE ? 250 : undefined,
-  });
+  };
+
+  if ( typeof process.env.CHROME_PATH !== 'undefined' && process.env.CHROME_PATH ) {
+    puppeterOptions.executablePath = process.env.CHROME_PATH ;
+  }
+
+  const browser = await puppeteer.launch(puppeterOptions);
+
   const page = await browser.newPage();
 
   page.on('console', (...args) => logger.info('PAGE LOG:', ...args));

--- a/src/core/pdf-core.js
+++ b/src/core/pdf-core.js
@@ -35,6 +35,7 @@ async function render(_opts = {}) {
   const browser = await puppeteer.launch({
     headless: !config.DEBUG_MODE,
     ignoreHTTPSErrors: opts.ignoreHttpsErrors,
+    executablePath: '/usr/bin/chromium-browser',
     args: ['--disable-gpu', '--no-sandbox', '--disable-setuid-sandbox'],
     sloMo: config.DEBUG_MODE ? 250 : undefined,
   });

--- a/src/index.js
+++ b/src/index.js
@@ -10,13 +10,15 @@ BPromise.config({
 });
 
 const app = createApp();
-const server = app.listen(config.PORT, () => {
+const server = app.listen(config.PORT, config.HOST, () => {
   logger.info(
-    'Express server listening on http://localhost:%d/ in %s mode',
+    'Express server listening on http://%s:%d/ in %s mode',
+    config.HOST,
     config.PORT,
     app.get('env')
   );
 });
+
 enableDestroy(server);
 
 function closeServer(signal) {

--- a/src/router.js
+++ b/src/router.js
@@ -53,6 +53,8 @@ function createRouter() {
     res.send('OK')
   })
 
+  router.use('/tmp', express.static(config.TMP_PATH));
+
   return router;
 }
 

--- a/src/router.js
+++ b/src/router.js
@@ -33,7 +33,7 @@ function createRouter() {
       allowUnknownQuery: false,
     },
   };
-  router.get('/api/render', validate(getRenderSchema), pdf.getRender);
+  router.get('/', validate(getRenderSchema), pdf.getRender);
 
   const postRenderSchema = {
     body: renderBodySchema,
@@ -47,7 +47,11 @@ function createRouter() {
       contextRequest: true,
     },
   };
-  router.post('/api/render', validate(postRenderSchema), pdf.postRender);
+  router.post('/', validate(postRenderSchema), pdf.postRender);
+
+  router.get('/health', function (req, res) {
+    res.send('OK')
+  })
 
   return router;
 }

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -37,8 +37,6 @@ const sharedQuerySchema = Joi.object({
   'viewport.isLandscape': Joi.boolean(),
   'goto.timeout': Joi.number().min(0).max(60000),
   'goto.waitUntil': Joi.string().min(1).max(2000),
-  'goto.networkIdleInflight': Joi.number().min(0).max(1000),
-  'goto.networkIdleTimeout': Joi.number().min(0).max(1000),
   'pdf.scale': Joi.number().min(0).max(1000),
   'pdf.displayHeaderFooter': Joi.boolean(),
   'pdf.landscape': Joi.boolean(),
@@ -80,8 +78,6 @@ const renderBodyObject = Joi.object({
   goto: Joi.object({
     timeout: Joi.number().min(0).max(60000),
     waitUntil: Joi.string().min(1).max(2000),
-    networkIdleInflight: Joi.number().min(0).max(1000),
-    networkIdleTimeout: Joi.number().min(0).max(1000),
   }),
   pdf: Joi.object({
     scale: Joi.number().min(0).max(1000),


### PR DESCRIPTION
Build based on puppeteer documentation https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md

Also based on some changes in https://github.com/alvarcarto/url-to-pdf-api/pull/48
It includes two builds for production and development use.

Production build uses NODE_ENV=production and makes small images (139MB compressed) with ready to use service in docker/kubernetes environment

Development build allow to modify code in local fs and uses docker-compose volumes.

```docker-compose up``` - to start application in development mode (NODE_ENV=development)
```docker-compose run app npm test``` - to run specs

All changes compatible to use application in local install same as before. It adds couple new ENV variables to allow to work with docker:

HOST=0.0.0.0 for Docker and fallback to localhost as on master
CHROME_PATH=/usr/bin/chromium-browser to use system chrome for alpine

Unofficial build also available at docker-hub.

```bash
docker run -p9000:9000 mgyk/url-to-pdf-api
curl "http://localhost:9000/api/render?url=https://github.com/" -o test.pdf
```

