### PR TITLE
allow to set charset in header of post request to api

### DIFF
--- a/src/http/pdf-http.js
+++ b/src/http/pdf-http.js
@@ -15,7 +15,7 @@ const getRender = ex.createRoute((req, res) => {
 });
 
 const postRender = ex.createRoute((req, res) => {
-  const isBodyJson = req.headers['content-type'] === 'application/json';
+  const isBodyJson = req.headers['content-type'].includes('application/json');
   if (isBodyJson) {
     const hasContent = _.isString(_.get(req.body, 'url')) || _.isString(_.get(req.body, 'html'));
     if (!hasContent) {


### PR DESCRIPTION
If set charset in http post request, header "Content-Type" will be like "application/json; charset=utf-8". So to check if body is json, we need to check that "Content-Type" not strictly equal "application/json" but includes "application/json".