### PR TITLE
feat: optionally fail if there are failed requests

### DIFF
--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -99,6 +99,7 @@ const renderBodyObject = Joi.object({
     }),
     printBackground: Joi.boolean(),
   }),
+  failEarly: Joi.string(),
 });
 
 const renderBodySchema = Joi.alternatives([


### PR DESCRIPTION
There are use-cases where the pdf is requested and processed
automatically, e.g. creation of personalized pdf which are sent out in
newsletters.

If the page or parts of it fail to load, then it may be preferable to
not create a PDF and report an error instead of creating a pdf of an
error page or of a page with, for example, missing images or missing
fonts.

This commit introduces a new option 'failEarly'. This can take the
values 'all' or 'page'. If any other value is used or the option is
omitted then the previous behavior is unchanged.
If the value for 'failEarly' is 'all', then the process fails with an 412
http error code and informs the client how many requests have failed.
Requests are considered failed if they returned a response with an http
status code equal or larger than 400.
If the value for 'failEarly' is 'page', then the process fails when the
request for the provided url results in any response other than 200.
This explicitly includes responses with the exit code of 302, which
might otherwise produce a valid PDF.