### PR TITLE
Tests fix to avoid errors in Travis CI

### DIFF
--- a/test/test-all.js
+++ b/test/test-all.js
@@ -43,10 +43,10 @@ describe('POST /api/render', () => {
       .expect(400)
   );
 
-  it('render google.com should succeed', () =>
+  it('render github.com should succeed', () =>
     request(app)
       .post('/api/render')
-      .send({ url: 'https://google.com' })
+      .send({ url: 'https://github.com' })
       .set('content-type', 'application/json')
       .expect(200)
       .expect('content-type', 'application/pdf')

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -48,6 +48,7 @@ describe('POST /api/render', () => {
       .post('/api/render')
       .send({ url: 'https://github.com' })
       .set('content-type', 'application/json')
+      .set('Connection', 'keep-alive')
       .expect(200)
       .expect('content-type', 'application/pdf')
       .then((response) => {
@@ -60,6 +61,7 @@ describe('POST /api/render', () => {
     request(app)
       .post('/api/render')
       .send({ html: getResource('postmark-receipt.html') })
+      .set('Connection', 'keep-alive')
       .set('content-type', 'application/json')
       .expect(200)
       .expect('content-type', 'application/pdf')
@@ -73,6 +75,7 @@ describe('POST /api/render', () => {
     request(app)
       .post('/api/render')
       .send(getResource('postmark-receipt.html'))
+      .set('Connection', 'keep-alive')
       .set('content-type', 'text/html')
       .expect(200)
       .expect('content-type', 'application/pdf')


### PR DESCRIPTION
Jenkins CI test failed with ECONNRESET error. May be it's a good idea to change remote host in 'render google.com should succeed' test to another (github.com for example) to avoid google banhammer.