### PR TITLE
Added ability to setExtraHTTPHeaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The only required parameter is `url`.
   // Passed to Puppeteer page.waitFor()
   waitFor: null,
 
-  // Passsed to Puppeteer page.setCookies()
+  // Passed to Puppeteer page.setCookies()
   cookies: [{ ... }]
 
   // Passed to Puppeteer page.setViewport()
@@ -228,6 +228,9 @@ The only required parameter is `url`.
 
   // Passed to Puppeteer page.pdf()
   pdf: { ... }
+  
+  // Passed to Puppeteer page.setExtraHTTPHeaders()
+  setExtraHTTPHeaders: { "key": "value" }
 }
 ```
 

--- a/src/core/pdf-core.js
+++ b/src/core/pdf-core.js
@@ -22,6 +22,7 @@ async function render(_opts = {}) {
       printBackground: true,
     },
     failEarly: false,
+	setExtraHTTPHeaders: {},
   }, _opts);
 
   if (_.get(_opts, 'pdf.width') && _.get(_opts, 'pdf.height')) {
@@ -80,6 +81,9 @@ async function render(_opts = {}) {
     opts.cookies.map(async (cookie) => {
       await page.setCookie(cookie);
     });
+	
+	logger.info('Setting headers...');
+	await page.setExtraHTTPHeaders(opts.setExtraHTTPHeaders);
 
     if (opts.html) {
       logger.info('Set HTML ..');

--- a/src/core/pdf-core.js
+++ b/src/core/pdf-core.js
@@ -82,8 +82,8 @@ async function render(_opts = {}) {
       await page.setCookie(cookie);
     });
 	
-	logger.info('Setting headers...');
-	await page.setExtraHTTPHeaders(opts.setExtraHTTPHeaders);
+    logger.info('Setting headers...');
+    await page.setExtraHTTPHeaders(opts.setExtraHTTPHeaders);
 
     if (opts.html) {
       logger.info('Set HTML ..');

--- a/src/core/pdf-core.js
+++ b/src/core/pdf-core.js
@@ -22,7 +22,7 @@ async function render(_opts = {}) {
       printBackground: true,
     },
     failEarly: false,
-	setExtraHTTPHeaders: {},
+    setExtraHTTPHeaders: {},
   }, _opts);
 
   if (_.get(_opts, 'pdf.width') && _.get(_opts, 'pdf.height')) {

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -53,6 +53,7 @@ const sharedQuerySchema = Joi.object({
   'pdf.margin.bottom': Joi.string().min(1).max(2000),
   'pdf.margin.left': Joi.string().min(1).max(2000),
   'pdf.printBackground': Joi.boolean(),
+  setExtraHTTPHeaders: Joi.object(),
 });
 
 const renderQuerySchema = Joi.object({
@@ -104,6 +105,7 @@ const renderBodyObject = Joi.object({
     printBackground: Joi.boolean(),
   }),
   failEarly: Joi.string(),
+  setExtraHTTPHeaders: Joi.object(),
 });
 
 const renderBodySchema = Joi.alternatives([


### PR DESCRIPTION
I have added the ability to send custom headers which will help a lot of folks to resolve issues passing along a token for auth or whatever other use case they may have.

An example usage of how this is to be used is:
```
    "setExtraHTTPHeaders": {
        "customHeader": "test"
    }
```

I'm a .NET developer by nature, but I needed this ability and I thought the community could benefit from it. Please let me know if there are any issues with this PR and I will update them.