### PR TITLE
Cookies setting fix after puppeteer update

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-import": "^2.7.0",
     "mocha": "^4.0.1",
     "nodemon": "^1.12.1",
-    "supertest": "^3.0.0"
+    "supertest": "^3.0.0",
+    "pdf2json": "^1.1.7"
   }
 }


### PR DESCRIPTION
Page.setCookies not working anymore due to the new version of puppeteer. Now, you can't set cookies with this function if page not loaded. This pull request fixes this problem by using chrome devtools protocol session. (Issue #62)