### PR TITLE
Update validation.js to accept waitUntil string or Array

### DIFF
--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -149,7 +149,6 @@ async function render(_opts = {}) {
 
       data = await page.screenshot(screenshotOpts);
     }
-
   } catch (err) {
     logger.error(`Error when rendering page: ${err}`);
     logger.error(err.stack);

--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -148,7 +148,7 @@ async function render(_opts = {}) {
       }
 
       data = await page.screenshot(screenshotOpts);
-    }
+    };
 
   } catch (err) {
     logger.error(`Error when rendering page: ${err}`);

--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -81,10 +81,12 @@ async function render(_opts = {}) {
       await page.emulateMedia('screen');
     }
 
-    logger.info('Setting cookies..');
-    opts.cookies.map(async (cookie) => {
-      await page.setCookie(cookie);
-    });
+    if (opts.cookies && opts.cookies.length > 0) {
+      logger.info('Setting cookies..');
+      const client = await page.target().createCDPSession();
+      await client.send('Network.enable');
+      await client.send('Network.setCookies', { cookies: opts.cookies });
+    }
 
     if (opts.html) {
       logger.info('Set HTML ..');
@@ -142,7 +144,7 @@ async function render(_opts = {}) {
       const screenshotOpts = _.cloneDeep(_.omit(opts.screenshot, ['clip']));
       const clipContainsSomething = _.some(opts.screenshot.clip, val => !_.isUndefined(val));
       if (clipContainsSomething) {
-        screenshotOpts.clip = opts.screenshot.clip
+        screenshotOpts.clip = opts.screenshot.clip;
       }
 
       data = await page.screenshot(screenshotOpts);

--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -148,7 +148,7 @@ async function render(_opts = {}) {
       }
 
       data = await page.screenshot(screenshotOpts);
-    };
+    }
 
   } catch (err) {
     logger.error(`Error when rendering page: ${err}`);

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -38,8 +38,8 @@ const sharedQuerySchema = Joi.object({
   'viewport.isLandscape': Joi.boolean(),
   'goto.timeout': Joi.number().min(0).max(60000),
   'goto.waitUntil': Joi.alternatives([
-      Joi.string().min(1).max(2000),
-      Joi.array()
+    Joi.string().min(1).max(2000),
+    Joi.array(),
   ]),
   'goto.networkIdleInflight': Joi.number().min(0).max(1000),
   'goto.networkIdleTimeout': Joi.number().min(0).max(1000),
@@ -96,7 +96,7 @@ const renderBodyObject = Joi.object({
     timeout: Joi.number().min(0).max(60000),
     waitUntil: Joi.alternatives([
       Joi.string().min(1).max(2000),
-      Joi.array()
+      Joi.array(),
     ]),
     networkIdleInflight: Joi.number().min(0).max(1000),
     networkIdleTimeout: Joi.number().min(0).max(1000),

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -37,7 +37,10 @@ const sharedQuerySchema = Joi.object({
   'viewport.hasTouch': Joi.boolean(),
   'viewport.isLandscape': Joi.boolean(),
   'goto.timeout': Joi.number().min(0).max(60000),
-  'goto.waitUntil': Joi.string().min(1).max(2000),
+  'goto.waitUntil': Joi.alternatives([
+      Joi.string().min(1).max(2000),
+      Joi.array()
+  ]),
   'goto.networkIdleInflight': Joi.number().min(0).max(1000),
   'goto.networkIdleTimeout': Joi.number().min(0).max(1000),
   'pdf.scale': Joi.number().min(0).max(1000),
@@ -91,7 +94,10 @@ const renderBodyObject = Joi.object({
   ]),
   goto: Joi.object({
     timeout: Joi.number().min(0).max(60000),
-    waitUntil: Joi.string().min(1).max(2000),
+    waitUntil: Joi.alternatives([
+      Joi.string().min(1).max(2000),
+      Joi.array()
+    ]),
     networkIdleInflight: Joi.number().min(0).max(1000),
     networkIdleTimeout: Joi.number().min(0).max(1000),
   }),


### PR DESCRIPTION
This simple patch to match Puppeteer API options. (no verificication on string/valid string in array alternative)
https://github.com/GoogleChrome/puppeteer/blob/v1.8.0/docs/api.md#pagegotourl-options
...waitUntil can be <string|Array<string>>