### PR TITLE
Directly set html content

### DIFF
--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -88,8 +88,7 @@ async function render(_opts = {}) {
 
     if (opts.html) {
       logger.info('Set HTML ..');
-      // https://github.com/GoogleChrome/puppeteer/issues/728
-      await page.goto(`data:text/html;charset=UTF-8,${opts.html}`, opts.goto);
+      await page.setContent(opts.html, opts.goto);
     } else {
       logger.info(`Goto url ${opts.url} ..`);
       await page.goto(opts.url, opts.goto);


### PR DESCRIPTION
Issue with `page.setContent` not properly loading relative assets has been fixed: https://github.com/GoogleChrome/puppeteer/issues/728

Similar workaround in another project that has been removed: https://github.com/joelgriffith/browserless/pull/106

Using `setContent` instead of a data url should also fix the escaping issue presented by https://github.com/alvarcarto/url-to-pdf-api/issues/90. I was actually running into that problem myself so went looking for a solution, to find this workaround unnecessary since the core issue has been resolved.

FWIW I've been running this PR's branch in production with success. The failing test is also failing on master, I could rebase once that has been resolved.
