### PR TITLE
add option to create a browser by connecting to a chrome websocket endpoint

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,7 @@ const config = {
   ALLOW_HTTP: process.env.ALLOW_HTTP === 'true',
   DEBUG_MODE: process.env.DEBUG_MODE === 'true',
   CORS_ORIGIN: process.env.CORS_ORIGIN || '*',
+  BROWSER_WS_ENDPOINT: process.env.BROWSER_WS_ENDPOINT,
   API_TOKENS: [],
 };
 

--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -3,6 +3,21 @@ const _ = require('lodash');
 const config = require('../config');
 const logger = require('../util/logger')(__filename);
 
+
+async function createBrowser(opts) {
+  const browserOpts = {
+    ignoreHTTPSErrors: opts.ignoreHttpsErrors,
+    sloMo: config.DEBUG_MODE ? 250 : undefined,
+  };
+  if (config.BROWSER_WS_ENDPOINT) {
+    browserOpts.browserWSEndpoint = config.BROWSER_WS_ENDPOINT;
+    return puppeteer.connect(browserOpts);
+  }
+  browserOpts.headless = !config.DEBUG_MODE;
+  browserOpts.args = ['--disable-gpu', '--no-sandbox', '--disable-setuid-sandbox'];
+  return puppeteer.launch(browserOpts);
+}
+
 async function render(_opts = {}) {
   const opts = _.merge({
     cookies: [],
@@ -37,12 +52,7 @@ async function render(_opts = {}) {
 
   logOpts(opts);
 
-  const browser = await puppeteer.launch({
-    headless: !config.DEBUG_MODE,
-    ignoreHTTPSErrors: opts.ignoreHttpsErrors,
-    args: ['--disable-gpu', '--no-sandbox', '--disable-setuid-sandbox'],
-    sloMo: config.DEBUG_MODE ? 250 : undefined,
-  });
+  const browser = await createBrowser(opts);
   const page = await browser.newPage();
 
   page.on('console', (...args) => logger.info('PAGE LOG:', ...args));


### PR DESCRIPTION
This comes in handy when sharing an already running instance of headless chrome between multiple services