### PR TITLE
Added option to override request

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ screenshot.clip.x | number | - | Specifies x-coordinate of top-left corner of cl
 screenshot.clip.y | number | - | Specifies y-coordinate of top-left corner of clipping region of the page.
 screenshot.clip.width | number | - | Specifies width of clipping region of the page.
 screenshot.clip.height | number | - | Specifies height of clipping region of the page.
+request.headers | object | - | (POST only) Override request headers.
+request.method | string | - | Override request method.
+request.postData | string | - | Override request postData.
 
 
 **Example:**
@@ -250,6 +253,9 @@ The only required parameter is `url`.
 
   // Passed to Puppeteer page.screenshot()
   screenshot: { ... },
+  
+  // Intercepts and overrides request
+  request: { ...},
 }
 ```
 

--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -1,5 +1,6 @@
 const puppeteer = require('puppeteer');
 const _ = require('lodash');
+const qs = require('qs');
 const config = require('../config');
 const logger = require('../util/logger')(__filename);
 
@@ -71,6 +72,14 @@ async function render(_opts = {}) {
       this.mainUrlResponse = response;
     }
   });
+
+  if (opts.request) {
+    await page.setRequestInterception(true);
+    page.on('request', (request) => {
+      request.continue(opts.request);
+    });
+  }
+
 
   let data;
   try {

--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -1,6 +1,5 @@
 const puppeteer = require('puppeteer');
 const _ = require('lodash');
-const qs = require('qs');
 const config = require('../config');
 const logger = require('../util/logger')(__filename);
 

--- a/src/http/render-http.js
+++ b/src/http/render-http.js
@@ -113,6 +113,11 @@ function getOptsFromQuery(query) {
       },
       omitBackground: query['screenshot.omitBackground'],
     },
+    request: {
+      headers: query['request.headers'],
+      method: query['request.method'],
+      postData: query['request.postData'],
+    },
   };
   return opts;
 }

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -62,6 +62,9 @@ const sharedQuerySchema = Joi.object({
   'screenshot.clip.width': Joi.number(),
   'screenshot.clip.height': Joi.number(),
   'screenshot.omitBackground': Joi.boolean(),
+  // 'request.headers': Joi.object(), // any way to send an object?
+  'request.method': Joi.string().valid(['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']),
+  'request.postData': Joi.string(),
 });
 
 const renderQuerySchema = Joi.object({
@@ -126,6 +129,11 @@ const renderBodyObject = Joi.object({
     omitBackground: Joi.boolean(),
   }),
   failEarly: Joi.string(),
+  request: Joi.object({
+    headers: Joi.object(),
+    method: Joi.string().valid(['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH']),
+    postData: Joi.string(),
+  }),
 });
 
 const renderBodySchema = Joi.alternatives([


### PR DESCRIPTION
This change allows overriding the request, so you can render a page that uses a post request.
Example:

    curl -X POST \
      https://url-to-pdf-api.herokuapp.com/api/render \
      -H 'Content-Type: application/json' \
      -H 'cache-control: no-cache' \
      -d '{ "url": "https://en.wikipedia.org/w/index.php", "request": { "method":"POST", "headers": { "cache-control": "no-cache", "content-type": "application/x-www-form-urlencoded" }, "postData": "search=pdf&title=Special%3ASearch&go=Go" } }'