### PR TITLE
Use env-cmd to load .env file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Guide:
 #
 # 1. Copy this file to .env
@@ -8,11 +6,9 @@
 #
 # 2. Fill the blanks
 
-export NODE_ENV=development
-export PORT=9000
-export ALLOW_HTTP=true
+NODE_ENV=development
+PORT=9000
+ALLOW_HTTP=true
 
 # Warning: PDF rendering does not work in Chrome when it is in headed mode.
-export DEBUG_MODE=false
-
-echo "Environment variables set!"
+DEBUG_MODE=false

--- a/README.md
+++ b/README.md
@@ -309,9 +309,6 @@ First, clone the repository and cd into it.
 
 * `cp .env.sample .env`
 * Fill in the blanks in `.env`
-* `source .env` or `bash .env`
-
-  Or use [autoenv](https://github.com/kennethreitz/autoenv).
 
 * `npm install`
 * `npm start` Start express server locally

--- a/package-lock.json
+++ b/package-lock.json
@@ -921,6 +921,37 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "env-cmd": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-9.0.1.tgz",
+      "integrity": "sha512-zFKkksLGn+JClAKd/McvT+K45K4ZbmFdaILPdvG86q2SxJ7/6v45RpP4/VbyACCRgeXz0f9Gt3Yr8klzKLq3gw==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "cross-spawn": "6.0.5"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -3077,6 +3108,12 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "node-ensure": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "10.x.x"
   },
   "scripts": {
-    "start": "nodemon --watch ./src -e js src/index.js",
+    "start": "env-cmd nodemon --watch ./src -e js src/index.js",
     "test": "mocha --timeout 10000 && npm run lint",
     "lint": "eslint ."
   },
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
+    "env-cmd": "^9.0.1",
     "eslint": "^4.8.0",
     "eslint-config-airbnb-base": "^12.0.2",
     "eslint-plugin-import": "^2.7.0",


### PR DESCRIPTION
Thanks for providing such a great microservice implementation! This small pull request aims to make the local development slightly easier.

Currently, for local development, the user needs to load environment variables manually. This is particularly cumbersome on Windows PCs since the `.env.sample` assumes environments that can natively run `bash`.

By using `env-cmd`, there is no need for such a manual loading process and the `README.md` can be a little bit shorter.