### PR TITLE
Point to different docker Image that is actually maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ and requests are direct connections to it.
 
 * Heavy pages may cause Chrome to crash if the server doesn't have enough RAM.
 
-* Docker wrapper for this can be found here: https://github.com/microbox/node-url-to-pdf-api
+* Docker image for this can be found here: https://github.com/restorecommerce/pdf-rendering-srv
 
 
 ## Examples


### PR DESCRIPTION
The previous image is no longer maintained also it does not even point to the correct source!
See this issue: https://github.com/microbox/node-url-to-pdf-api/issues/4
We have built a new image that we will maintain also in the future as part for Restorecommerce.