### PR TITLE
Implement opts.pdf.fullPage

### DIFF
--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -44,7 +44,7 @@ async function render(_opts = {}) {
     failEarly: false,
   }, _opts);
 
-  if (_.get(_opts, 'pdf.width') && _.get(_opts, 'pdf.height')) {
+  if (_.get(_opts, 'pdf.width') && _.get(_opts, 'pdf.height') || _.get(_opts, 'pdf.fullPage')) {
     // pdf.format always overrides width and height, so we must delete it
     // when user explicitly wants to set width and height
     opts.pdf.format = undefined;
@@ -148,6 +148,12 @@ async function render(_opts = {}) {
     }
 
     if (opts.output === 'pdf') {
+      if (opts.pdf.fullPage) {
+        const offsetHeight = await page.evaluate(() => document.documentElement.offsetHeight);
+        const scrollHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+        // For some reason offsetHeight equals to viewport height in local tests
+        opts.pdf.height = `${Math.max(offsetHeight, scrollHeight)}px`;
+      }
       data = await page.pdf(opts.pdf);
     } else {
       // This is done because puppeteer throws an error if fullPage and clip is used at the same

--- a/src/http/render-http.js
+++ b/src/http/render-http.js
@@ -84,6 +84,7 @@ function getOptsFromQuery(query) {
       networkIdleTimeout: query['goto.networkIdleTimeout'],
     },
     pdf: {
+      fullPage: query['pdf.fullPage'],
       scale: query['pdf.scale'],
       displayHeaderFooter: query['pdf.displayHeaderFooter'],
       footerTemplate: query['pdf.footerTemplate'],

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -41,6 +41,7 @@ const sharedQuerySchema = Joi.object({
   'goto.networkIdleInflight': Joi.number().min(0).max(1000),
   'goto.networkIdleTimeout': Joi.number().min(0).max(1000),
   'pdf.scale': Joi.number().min(0).max(1000),
+  'pdf.fullPage': Joi.boolean(),
   'pdf.displayHeaderFooter': Joi.boolean(),
   'pdf.landscape': Joi.boolean(),
   'pdf.pageRanges': Joi.string().min(1).max(2000),
@@ -97,6 +98,7 @@ const renderBodyObject = Joi.object({
   }),
   pdf: Joi.object({
     scale: Joi.number().min(0).max(1000),
+    fullPage: Joi.boolean(),
     displayHeaderFooter: Joi.boolean(),
     landscape: Joi.boolean(),
     pageRanges: Joi.string().min(1).max(2000),


### PR DESCRIPTION
This allows to take PDFs which have the full page height. However it doesn't seem to work properly. Many sites end up printing two pages for some reason. 

Also the `document.documentElement.offsetHeight` advised here: https://github.com/GoogleChrome/puppeteer/issues/475 does not work for some reason. Possibly because we have emulateScreenMedia=true by default