### PR TITLE
implement setExtraHTTPHeaders

### DIFF
--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -100,6 +100,12 @@ async function render(_opts = {}) {
       await client.send('Network.setCookies', { cookies: opts.cookies });
     }
 
+	if (opts.setExtraHTTPHeaders) {
+      logger.info('Set setExtraHTTPHeaders ..');
+      await page.setExtraHTTPHeaders(opts.setExtraHTTPHeaders);
+    } 
+	
+	
     if (opts.html) {
       logger.info('Set HTML ..');
       await page.setContent(opts.html, opts.goto);

--- a/src/http/render-http.js
+++ b/src/http/render-http.js
@@ -113,6 +113,7 @@ function getOptsFromQuery(query) {
       },
       omitBackground: query['screenshot.omitBackground'],
     },
+    setExtraHTTPHeaders:query['setExtraHTTPHeaders'],
   };
   return opts;
 }

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -62,6 +62,7 @@ const sharedQuerySchema = Joi.object({
   'screenshot.clip.width': Joi.number(),
   'screenshot.clip.height': Joi.number(),
   'screenshot.omitBackground': Joi.boolean(),
+  'setExtraHTTPHeaders': Joi.object(),
 });
 
 const renderQuerySchema = Joi.object({
@@ -126,6 +127,7 @@ const renderBodyObject = Joi.object({
     omitBackground: Joi.boolean(),
   }),
   failEarly: Joi.string(),
+  setExtraHTTPHeaders: Joi.object(),
 });
 
 const renderBodySchema = Joi.alternatives([


### PR DESCRIPTION
setExtraHTTPHeaders allows additional headers to be set on the url requested for PDF conversion.
This can be pretty useful for requests that require authentication

e.g. for Bearer tokens, add:
"setExtraHTTPHeaders":{
    "Authorization" :"Bearer your-bearer-token"
}





