### PR TITLE
Adding enableGPU to enable GPU usage in headless chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Parameter | Type | Default | Description
 url | string | - | URL to render as PDF. (required)
 output | string | pdf | Specify the output format. Possible values: `pdf` or `screenshot`.
 emulateScreenMedia | boolean | `true` | Emulates `@media screen` when rendering the PDF.
-enableGPU | boolean | 'false' | When set, enables chrome GPU. For windows user, this will always return false.
+enableGPU | boolean | `false` | When set, enables chrome GPU. For windows user, this will always return false. See https://developers.google.com/web/updates/2017/04/headless-chrome
 ignoreHttpsErrors | boolean | `false` | Ignores possible HTTPS errors when navigating to a page.
 scrollPage | boolean | `false` | Scroll page down before rendering to trigger lazy loading elements.
 waitFor | number or string | - | Number in ms to wait before render or selector element to wait before render.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Parameter | Type | Default | Description
 url | string | - | URL to render as PDF. (required)
 output | string | pdf | Specify the output format. Possible values: `pdf` or `screenshot`.
 emulateScreenMedia | boolean | `true` | Emulates `@media screen` when rendering the PDF.
+enableGPU | boolean | 'false' | When set, enables chrome GPU. For windows user, this will always return false.
 ignoreHttpsErrors | boolean | `false` | Ignores possible HTTPS errors when navigating to a page.
 scrollPage | boolean | `false` | Scroll page down before rendering to trigger lazy loading elements.
 waitFor | number or string | - | Number in ms to wait before render or selector element to wait before render.

--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -17,7 +17,10 @@ async function createBrowser(opts) {
     browserOpts.executablePath = config.BROWSER_EXECUTABLE_PATH;
   }
   browserOpts.headless = !config.DEBUG_MODE;
-  browserOpts.args = ['--disable-gpu', '--no-sandbox', '--disable-setuid-sandbox'];
+  browserOpts.args = ['--no-sandbox', '--disable-setuid-sandbox'];
+  if (!opts.enableGPU || navigator.userAgent.indexOf("Win") != -1) {
+    browserOpts.args.push('--disable-gpu');
+  }
   return puppeteer.launch(browserOpts);
 }
 

--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -18,7 +18,7 @@ async function createBrowser(opts) {
   }
   browserOpts.headless = !config.DEBUG_MODE;
   browserOpts.args = ['--no-sandbox', '--disable-setuid-sandbox'];
-  if (!opts.enableGPU || navigator.userAgent.indexOf("Win") != -1) {
+  if (!opts.enableGPU || navigator.userAgent.indexOf('Win') !== -1) {
     browserOpts.args.push('--disable-gpu');
   }
   return puppeteer.launch(browserOpts);

--- a/src/http/render-http.js
+++ b/src/http/render-http.js
@@ -69,6 +69,7 @@ function getOptsFromQuery(query) {
     attachmentName: query.attachmentName,
     scrollPage: query.scrollPage,
     emulateScreenMedia: query.emulateScreenMedia,
+    enableGPU: query.enableGPU,
     ignoreHttpsErrors: query.ignoreHttpsErrors,
     waitFor: query.waitFor,
     output: query.output || 'pdf',

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -23,6 +23,7 @@ const sharedQuerySchema = Joi.object({
   attachmentName: Joi.string(),
   scrollPage: Joi.boolean(),
   emulateScreenMedia: Joi.boolean(),
+  enableGPU: Joi.boolean(),
   ignoreHttpsErrors: Joi.boolean(),
   waitFor: Joi.alternatives([
     Joi.number().min(1).max(60000),


### PR DESCRIPTION
I'm using a library (mapboxGL) that requires the GPU to render certain services. By default chrome runs with `--disable-gpu`.

I've set the conditional statement for Windows users because the chrome document says it is an ongoing issue https://bugs.chromium.org/p/chromium/issues/detail?id=737678

