### PR TITLE
Add screenshot selector. Feature related to https://github.com/alvarc…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/src/index.js",
+            "env": {
+                "NODE_ENV": "development",
+                "PORT": "9000",
+                "ALLOW_HTTP": "true",
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The only required parameter is `url`.
 Parameter | Type | Default | Description
 ----------|------|---------|------------
 url | string | - | URL to render as PDF. (required)
-output | string | pdf | Specify the output format. Possible values: `pdf` or `screenshot`.
+output | string | pdf | Specify the output format. Possible values: `pdf` , `screenshot` or `html`.
 emulateScreenMedia | boolean | `true` | Emulates `@media screen` when rendering the PDF.
 ignoreHttpsErrors | boolean | `false` | Ignores possible HTTPS errors when navigating to a page.
 scrollPage | boolean | `false` | Scroll page down before rendering to trigger lazy loading elements.

--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -162,8 +162,14 @@ async function render(_opts = {}) {
       if (clipContainsSomething) {
         screenshotOpts.clip = opts.screenshot.clip;
       }
-
-      data = await page.screenshot(screenshotOpts);
+      if(_.isNil(opts.screenshot.selector)) {
+        data = await page.screenshot(screenshotOpts);
+      }else {
+        const selElement = await page.$(opts.screenshot.selector);
+        if (!_.isNull(selElement)) {
+          data = await selElement.screenshot();
+        } 
+      }
     }
   } catch (err) {
     logger.error(`Error when rendering page: ${err}`);
@@ -175,7 +181,7 @@ async function render(_opts = {}) {
       await browser.close();
     }
   }
-
+  
   return data;
 }
 

--- a/src/http/render-http.js
+++ b/src/http/render-http.js
@@ -185,6 +185,7 @@ function getOptsFromQuery(query) {
         width: query['screenshot.clip.width'],
         height: query['screenshot.clip.height'],
       },
+      selector: query['screenshot.selector'],
       omitBackground: query['screenshot.omitBackground'],
     },
   };

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -61,6 +61,7 @@ const sharedQuerySchema = Joi.object({
   'screenshot.clip.y': Joi.number(),
   'screenshot.clip.width': Joi.number(),
   'screenshot.clip.height': Joi.number(),
+  'screenshot.selector': Joi.string().regex(/(#|\.).*/),
   'screenshot.omitBackground': Joi.boolean(),
 });
 
@@ -123,6 +124,7 @@ const renderBodyObject = Joi.object({
       width: Joi.number(),
       height: Joi.number(),
     },
+    selector: Joi.string().regex(/(#|\.).*/),
     omitBackground: Joi.boolean(),
   }),
   failEarly: Joi.string(),


### PR DESCRIPTION
…arto/url-to-pdf-api/issues/125 request

Add feature screenshot selector to support requested improvement https://github.com/alvarcarto/url-to-pdf-api/issues/125

**Developer Comment**
- New attribute introduced in screenshot object called "selector".
- "selector" attribute could be html css id or class.
- "selector" validate using regex to only accept css id or class.
- POST and GET method have been dev tested.

Samples

1. Post request Example

`curl --location --request POST 'http://localhost:9000/api/render' \
--header 'Content-Type: application/json' \
--header 'Content-Type: application/javascript' \
--data-raw '{
	"output": "screenshot",
    "url": "https://expressjs.com/en/starter/hello-world.html",
    "screenshot": {
    	"selector": "#license"
    }
}'`

2. Get request example

http://localhost:9000/api/render?output=screenshot&screenshot.selector=%23license&url=https://expressjs.com/en/starter/hello-world.html

**Note**

- .vscode/launch.json file add to the project to make it easy to debug.