### PR TITLE
Remove old goto options, update documentation and default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,7 @@ cookies[0][httpOnly] | boolean | - | Cookie httpOnly
 cookies[0][secure] | boolean | - | Cookie secure
 cookies[0][sameSite] | string | - | `Strict` or `Lax`
 goto.timeout | number | `30000` |  Maximum navigation time in milliseconds, defaults to 30 seconds, pass 0 to disable timeout.
-goto.waitUntil | string | `networkidle` | When to consider navigation succeeded. Options: `load`, `networkidle`. `load` = consider navigation to be finished when the load event is fired. `networkidle` = consider navigation to be finished when the network activity stays "idle" for at least `goto.networkIdleTimeout` ms.
-goto.networkIdleInflight | number | `2` | Maximum amount of inflight requests which are considered "idle". Takes effect only with `goto.waitUntil`: 'networkidle' parameter.
-goto.networkIdleTimeout | number | `2000` | A timeout to wait before completing navigation. Takes effect only with waitUntil: 'networkidle' parameter.
+goto.waitUntil | string | `networkidle2` | When to consider navigation succeeded. Options: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`. `load` - consider navigation to be finished when the load event is fired. `domcontentloaded` - consider navigation to be finished when the `DOMContentLoaded` event is fired. `networkidle0` - consider navigation to be finished when there are no more than 0 network connections for at least `500` ms. `networkidle2` - consider navigation to be finished when there are no more than 2 network connections for at least `500` ms.
 pdf.scale | number | `1` | Scale of the webpage rendering.
 pdf.printBackground | boolean | `false`| Print background graphics.
 pdf.displayHeaderFooter | boolean | `false` | Display header and footer.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ cookies[0][httpOnly] | boolean | - | Cookie httpOnly
 cookies[0][secure] | boolean | - | Cookie secure
 cookies[0][sameSite] | string | - | `Strict` or `Lax`
 goto.timeout | number | `30000` |  Maximum navigation time in milliseconds, defaults to 30 seconds, pass 0 to disable timeout.
-goto.waitUntil | string | `networkidle2` | When to consider navigation succeeded. Options: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`. `load` - consider navigation to be finished when the load event is fired. `domcontentloaded` - consider navigation to be finished when the `DOMContentLoaded` event is fired. `networkidle0` - consider navigation to be finished when there are no more than 0 network connections for at least `500` ms. `networkidle2` - consider navigation to be finished when there are no more than 2 network connections for at least `500` ms.
+goto.waitUntil | string | `networkidle0` | When to consider navigation succeeded. Options: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`. `load` - consider navigation to be finished when the load event is fired. `domcontentloaded` - consider navigation to be finished when the `DOMContentLoaded` event is fired. `networkidle0` - consider navigation to be finished when there are no more than 0 network connections for at least `500` ms. `networkidle2` - consider navigation to be finished when there are no more than 2 network connections for at least `500` ms.
 pdf.scale | number | `1` | Scale of the webpage rendering.
 pdf.printBackground | boolean | `false`| Print background graphics.
 pdf.displayHeaderFooter | boolean | `false` | Display header and footer.

--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -36,7 +36,7 @@ async function render(_opts = {}) {
       height: 1200,
     },
     goto: {
-      waitUntil: 'networkidle2',
+      waitUntil: 'networkidle0',
     },
     output: 'pdf',
     pdf: {
@@ -171,7 +171,7 @@ async function render(_opts = {}) {
         const selElement = await page.$(opts.screenshot.selector);
         if (!_.isNull(selElement)) {
           data = await selElement.screenshot();
-        } 
+        }
       }
     }
   } catch (err) {
@@ -184,7 +184,7 @@ async function render(_opts = {}) {
       await browser.close();
     }
   }
-  
+
   return data;
 }
 

--- a/src/http/render-http.js
+++ b/src/http/render-http.js
@@ -155,8 +155,6 @@ function getOptsFromQuery(query) {
     goto: {
       timeout: query['goto.timeout'],
       waitUntil: query['goto.waitUntil'],
-      networkIdleInflight: query['goto.networkIdleInflight'],
-      networkIdleTimeout: query['goto.networkIdleTimeout'],
     },
     pdf: {
       scale: query['pdf.scale'],

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -39,8 +39,6 @@ const sharedQuerySchema = Joi.object({
   'viewport.isLandscape': Joi.boolean(),
   'goto.timeout': Joi.number().min(0).max(60000),
   'goto.waitUntil': Joi.string().min(1).max(2000),
-  'goto.networkIdleInflight': Joi.number().min(0).max(1000),
-  'goto.networkIdleTimeout': Joi.number().min(0).max(1000),
   'pdf.scale': Joi.number().min(0).max(1000),
   'pdf.displayHeaderFooter': Joi.boolean(),
   'pdf.landscape': Joi.boolean(),
@@ -94,8 +92,6 @@ const renderBodyObject = Joi.object({
   goto: Joi.object({
     timeout: Joi.number().min(0).max(60000),
     waitUntil: Joi.string().min(1).max(2000),
-    networkIdleInflight: Joi.number().min(0).max(1000),
-    networkIdleTimeout: Joi.number().min(0).max(1000),
   }),
   pdf: Joi.object({
     scale: Joi.number().min(0).max(1000),


### PR DESCRIPTION
Hello!

While using this library, we've seen that the readme and the code still mentioned options `networkIdleInflight` and `networkIdleTimeout`. Those options are [long gone from Puppeteer](puppeteer/puppeteer@ce8a952). I updated the readme and removed references to those options in the code.

I also changed the default from `networkidle2` to `networkidle0`. [Based on the doc](https://github.com/puppeteer/puppeteer/blob/v5.0.0/docs/api.md#pagegotourl-options), this seems the most logical options users would want when rendering. I've made a separate commit for that so it can be removed if you would rather not change the current default.