### PR TITLE
output: :html to return full page (instead of body only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+* change the `:html` output to return `document.documentElement.innerHTML` instead of previously used `document.body.innerHTML`
+
 ## 1.0.0
 
 * initial version

--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -174,7 +174,7 @@ async function render(_opts = {}) {
       }
       data = await page.pdf(opts.pdf);
     } else if (opts.output === 'html') {
-      data = await page.evaluate(() => document.body.innerHTML);
+      data = await page.evaluate(() => document.documentElement.innerHTML);
     } else {
       // This is done because puppeteer throws an error if fullPage and clip is used at the same
       // time even though clip is just empty object {}
@@ -248,4 +248,3 @@ function logOpts(opts) {
 module.exports = {
   render,
 };
-


### PR DESCRIPTION
Can we have the `output: html` option return HTML of the whole document (`document.documentElement.innerHTML` incl. the `<head>` tag etc.) instead of the current body only (`document.body.innerHTML`)? It's easy enough to extract the body from the response, if needed. Thank you!