### PR TITLE
Support API keys in GET /api/render

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -13,7 +13,7 @@ function createRouter() {
     logger.info('x-api-key authentication required');
 
     router.use('/*', (req, res, next) => {
-      const userToken = req.headers['x-api-key'];
+      const userToken = (req.method === 'GET') ? req.query.apiKey : req.headers['x-api-key'];
       if (!_.includes(config.API_TOKENS, userToken)) {
         const err = new Error('Invalid API token in x-api-key header.');
         err.status = 401;

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -20,6 +20,7 @@ const cookieSchema = Joi.object({
 });
 
 const sharedQuerySchema = Joi.object({
+  apiKey: Joi.string(),
   attachmentName: Joi.string(),
   scrollPage: Joi.boolean(),
   emulateScreenMedia: Joi.boolean(),


### PR DESCRIPTION
This commit updates the authentication check so GET requests can, as POST requests already do, utilize the API_TOKENS for authentication.