### PR TITLE
Basic auth support

### DIFF
--- a/src/core/render-core.js
+++ b/src/core/render-core.js
@@ -74,6 +74,13 @@ async function render(_opts = {}) {
 
   const browser = await createBrowser(opts);
   const page = await browser.newPage();
+  
+  if (opts.authenticate && opts.authenticate.username && opts.authenticate.password) {
+    await page.authenticate({
+      username: opts.authenticate.username,
+      password: opts.authenticate.password,
+    });  
+  }
 
   page.on('console', (...args) => logger.info('PAGE LOG:', ...args));
 

--- a/src/http/render-http.js
+++ b/src/http/render-http.js
@@ -188,6 +188,10 @@ function getOptsFromQuery(query) {
       selector: query['screenshot.selector'],
       omitBackground: query['screenshot.omitBackground'],
     },
+    authenticate: {
+      username: query['authenticate.username'],
+      password: query['authenticate.password'],
+    }
   };
   return opts;
 }

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -63,6 +63,8 @@ const sharedQuerySchema = Joi.object({
   'screenshot.clip.height': Joi.number(),
   'screenshot.selector': Joi.string().regex(/(#|\.).*/),
   'screenshot.omitBackground': Joi.boolean(),
+  'authenticate.username': Joi.string(),
+  'authenticate.password': Joi.string(),
 });
 
 const renderQuerySchema = Joi.object({


### PR DESCRIPTION
Allow to specify `authenticate.username` and `authenticate.password` parameters for basic auth support.