### PR TITLE
use env in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: NODE_ENV=production node src/index.js
+web: env NODE_ENV=production node src/index.js


### PR DESCRIPTION
Close #149 

We might even remove `NODE_ENV` from the Procfile ? I'm not aware of best practice regarding this file.