### PR TITLE
Drop bluebird dependency, use native Promise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -313,11 +313,6 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
-    "bluebird": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
-    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/alvarcarto/url-to-pdf-api#readme",
   "dependencies": {
-    "bluebird": "^3.5.0",
     "body-parser": "^1.18.2",
     "compression": "^1.7.1",
     "cors": "^2.8.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,7 @@
 const createApp = require('./app');
 const enableDestroy = require('server-destroy');
-const BPromise = require('bluebird');
 const logger = require('./util/logger')(__filename);
 const config = require('./config');
-
-BPromise.config({
-  warnings: config.NODE_ENV !== 'production',
-  longStackTraces: true,
-});
 
 const app = createApp();
 const server = app.listen(config.PORT, () => {

--- a/src/util/express.js
+++ b/src/util/express.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const BPromise = require('bluebird');
 
 // Route which assumes that the Promise `func` returns, will be resolved
 // with data which will be sent as json response.
@@ -28,7 +27,7 @@ function createRoute(func, responseHandler) {
       let valuePromise = callback();
       if (!_.isFunction(_.get(valuePromise, 'then'))) {
         // It was a not a Promise, so wrap it as a Promise
-        valuePromise = BPromise.resolve(valuePromise);
+        valuePromise = Promise.resolve(valuePromise);
       }
 
       if (_.isFunction(responseHandler)) {

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -3,16 +3,11 @@
 const chai = require('chai');
 const fs = require('fs');
 const request = require('supertest');
-const BPromise = require('bluebird');
 const { getResource } = require('./util');
 const pdf = require('pdf-parse');
 const createApp = require('../src/app');
 
 const DEBUG = false;
-
-BPromise.config({
-  longStackTraces: true,
-});
 
 const app = createApp();
 


### PR DESCRIPTION
Node.js provides native Promise API for more than six years. Node.js
versions older than that are unmaintained and unsupported for many
years. Thus Bluebird dependency is completely unnecessary.

Resolves #159