### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,14 @@ curl -o receipt.html https://rawgit.com/wildbit/postmark-templates/master/templa
 curl -o html.pdf -XPOST -d@receipt.html -H"content-type: text/html" http://localhost:9000/api/render?pdf.scale=1
 ```
 
+### GET /healthcheck
+
+Health check endpoint used for monitoring if the service is still up and running.
+
+```bash
+curl -XGET http://localhost:9000/healthcheck
+```
+
 ## Development
 
 To get this thing running, you have two options: run it in Heroku, or locally.

--- a/src/router.js
+++ b/src/router.js
@@ -49,6 +49,8 @@ function createRouter() {
   };
   router.post('/api/render', validate(postRenderSchema), render.postRender);
 
+  router.get('/healthcheck', (req, res) => res.status(200).send('OK'));
+
   return router;
 }
 

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -210,3 +210,7 @@ describe('POST /api/render', () => {
       })
   );
 });
+
+describe('GET /healthcheck', () => {
+  it('should return ok', () => request(app).get('/healthcheck').expect(200));
+});


### PR DESCRIPTION
Similar to https://github.com/alvarcarto/url-to-pdf-api/issues/100, we needed a healthcheck endpoint to know if the service is still up. Hopefully you'll consider this, cheers.